### PR TITLE
Update styling to outline theme

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 
 const themeClassMap = {
-  default: 'border-purple-700 bg-purple-700 text-white hover:bg-purple-500 hover:border-purple-500',
-  outline: 'border-purple-700 bg-transparent text-purple-700 hover:text-purple-500 hover:border-purple-500',
+  default: 'border-gray-900 bg-gray-900 text-white hover:bg-gray-700 hover:border-gray-700',
+  outline: 'border-gray-900 bg-transparent text-gray-900 hover:bg-gray-900 hover:text-white hover:border-gray-900',
 };
 
 export const Button = (props) => {

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -9,14 +9,14 @@ const themeClassMap = {
 
 export const Hero = (props) => {
   return (
-    <div className="px-6 py-16 bg-gray-100 sm:px-12 sm:py-24" data-sb-object-id={props.id}>
+    <div className="px-6 py-16 bg-white border border-gray-300 rounded-md sm:px-12 sm:py-24" data-sb-object-id={props.id}>
       <div className={`max-w-6xl mx-auto flex flex-col gap-12 md:items-center ${themeClassMap[props.theme] ?? themeClassMap['imgRight']}`}>
         <div className="flex-1 w-full max-w-xl mx-auto">
-          <h1 className="mb-6 text-4xl font-bold sm:text-5xl" data-sb-field-path="heading">
+          <h1 className="mb-6 text-4xl font-bold sm:text-5xl text-gray-800" data-sb-field-path="heading">
             {props.heading}
           </h1>
           {props.body && (
-            <Markdown options={{ forceBlock: true }} className="mb-6 text-lg" data-sb-field-path="body">
+            <Markdown options={{ forceBlock: true }} className="mb-6 text-lg text-gray-600" data-sb-field-path="body">
               {props.body}
             </Markdown>
           )}

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -1,6 +1,7 @@
 import Markdown from 'markdown-to-jsx';
 
 const themeClassMap = {
+  outline: 'bg-white border border-gray-300 text-gray-800',
   primary: 'bg-purple-700 text-white',
   dark: 'bg-gray-800 text-white',
 };
@@ -8,15 +9,15 @@ const themeClassMap = {
 export const Stats = (props) => {
   return (
     <div
-      className={`px-6 py-16 text-center ${themeClassMap[props.theme] ?? themeClassMap['primary']} sm:px-12 sm:py-24`}
+      className={`px-6 py-16 text-center rounded-md ${themeClassMap[props.theme] ?? themeClassMap['outline']} sm:px-12 sm:py-24`}
       data-sb-object-id={props.id}
     >
       <div className="mx-auto">
         <div className="mb-16">
-          <h2 className="mb-4 text-4xl font-bold sm:text-5xl" data-sb-field-path="heading">
+          <h2 className="mb-4 text-4xl font-bold sm:text-5xl text-gray-800" data-sb-field-path="heading">
             {props.heading}
           </h2>
-          {props.body && <Markdown options={{ forceBlock: true }} className="sm:text-lg" data-sb-field-path="body">
+          {props.body && <Markdown options={{ forceBlock: true }} className="sm:text-lg text-gray-600" data-sb-field-path="body">
             {props.body}
           </Markdown>}
         </div>
@@ -31,10 +32,10 @@ export const Stats = (props) => {
 const StatItem = (props) => {
   return (
     <div data-sb-object-id={props.id}>
-      <div className="mb-3 text-4xl font-bold sm:text-5xl" data-sb-field-path="value">
+      <div className="mb-3 text-4xl font-bold sm:text-5xl text-gray-800" data-sb-field-path="value">
         {props.value}
       </div>
-      <div data-sb-field-path="label">{props.label}</div>
+      <div className="text-gray-600" data-sb-field-path="label">{props.label}</div>
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,1 +1,5 @@
 @import 'tailwindcss';
+
+body {
+  @apply bg-gray-50 text-gray-900 font-sans;
+}


### PR DESCRIPTION
## Summary
- change global body style for light outline theme
- style Hero and Stats sections with outlined borders and muted text
- adjust button colors to gray outline style

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848fe577da08323870b2dbd6cf01c8d